### PR TITLE
[FEATURE] #1 Add ddev commands for each TYPO3 cli

### DIFF
--- a/.ddev/commands/web/v10-typo3
+++ b/.ddev/commands/web/v10-typo3
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+## Description: Use v10 typo3 CLI
+## Usage: v10-typo3
+## Example: "ddev v10-typo3 --version"
+
+v10/vendor/bin/typo3 $@

--- a/.ddev/commands/web/v10-typo3cms
+++ b/.ddev/commands/web/v10-typo3cms
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+## Description: Use v10 typo3cms CLI
+## Usage: v10-typo3cms
+## Example: "ddev v10-typo3cms --version"
+
+v10/vendor/bin/typo3cms $@

--- a/.ddev/commands/web/v8-typo3cms
+++ b/.ddev/commands/web/v8-typo3cms
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+## Description: Use v8 typo3cms CLI
+## Usage: v8-typo3cms
+## Example: "ddev v8-typo3cms --version"
+
+v8/vendor/bin/typo3cms $@

--- a/.ddev/commands/web/v9-typo3
+++ b/.ddev/commands/web/v9-typo3
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+## Description: Use v9 typo3 CLI
+## Usage: v9-typo3
+## Example: "ddev v9-typo3 --version"
+
+v9/vendor/bin/typo3 $@

--- a/.ddev/commands/web/v9-typo3cms
+++ b/.ddev/commands/web/v9-typo3cms
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+## Description: Use v9 typo3cms CLI
+## Usage: v9-typo3cms
+## Example: "ddev v9-typo3cms --version"
+
+v9/vendor/bin/typo3cms $@

--- a/README.md
+++ b/README.md
@@ -131,6 +131,20 @@ $ ddev exec v10/vendor/bin/typo3cms
 
 *Note: Replace ``v10`` with the version you want to address*
 
+In addition to the full path you can use a ddev command like that:
+
+```
+# v8
+$ ddev v8-typo3cms
+
+# v9
+$ ddev v9-typo3
+$ ddev v9-typo3cms
+
+# v10
+$ ddev v10-typo3
+$ ddev v10-typo3cms
+```
 
 ### Render and view documentation
 


### PR DESCRIPTION
`v8/vendor/bin/typo3` is omitted because it's non existent.

Example calls are added to the README.md file.