### PR TITLE
Use ghcr.io/t3docs/render-documentation to render docs

### DIFF
--- a/.ddev/docker-compose.docs.yaml
+++ b/.ddev/docker-compose.docs.yaml
@@ -1,7 +1,7 @@
 version: "3.6"
 services:
     docs:
-        image: t3docs/render-documentation:latest
+        image: ghcr.io/t3docs/render-documentation:latest
         command: makehtml
         volumes:
             - ../:/PROJECT:ro


### PR DESCRIPTION
the container is now hosted on github container registry.